### PR TITLE
Add Django 1.11 support, bump dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TOXENV=django18
   - TOXENV=django19
   - TOXENV=django110
+  - TOXENV=django111
 
 matrix:
   include:
@@ -18,7 +19,7 @@ matrix:
 
 cache:
   - pip
-  
+
 before_install:
   - pip install --upgrade pip
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Ned Batchelder <ned@edx.org>
+Brian Mesick <bmesick@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,17 @@ Change Log
    in this file.  It adheres to the structure of http://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (http://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
+
+[1.0.3] - 2017-07-17
+====================
+
+* Updated tests to support Django 1.11
+* Updated dependency versions
+
 
 [1.0.2] - 2017-05-16
 ====================

--- a/help_tokens/__init__.py
+++ b/help_tokens/__init__.py
@@ -7,6 +7,6 @@ from __future__ import absolute_import, unicode_literals
 from .context_processor import context_processor
 
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 default_app_config = 'help_tokens.apps.HelpTokensConfig'  # pylint: disable=invalid-name

--- a/help_tokens/core.py
+++ b/help_tokens/core.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, unicode_literals
 import logging
 
 from django.conf import settings
+
 from six.moves import configparser
 
 log = logging.getLogger(__name__)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
 # Core requirements for using this application
 
 Django                    # Web application framework
-
+six                       # Python 3 compatibility layer

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,3 +6,4 @@
 #
 django==1.11
 pytz==2017.2              # via django
+six==1.10.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,27 +5,28 @@
 #    pip-compile --output-file requirements/dev.txt requirements/base.in requirements/dev.in requirements/quality.in
 #
 argparse==1.4.0           # via caniusepython3
-args==0.1.0               # via clint
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
 backports.functools-lru-cache==1.4  # via astroid, caniusepython3, pylint
 bleach==2.0.0             # via readme-renderer
 caniusepython3==5.0.0
+certifi==2017.4.17        # via requests
+chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
-clint==0.5.1              # via twine
 configparser==3.5.0       # via pylint
 diff-cover==0.9.11
 distlib==0.2.5            # via caniusepython3
-django==1.10.7            # via edx-i18n-tools
+django==1.11.2            # via edx-i18n-tools
 docutils==0.13.1          # via readme-renderer
-edx-i18n-tools==0.3.7
+edx-i18n-tools==0.3.9
 edx-lint==0.5.4
 enum34==1.1.6             # via astroid
 first==2.0.1              # via pip-tools
 futures==3.1.1            # via caniusepython3
 html5lib==0.999999999     # via bleach
+idna==2.5                 # via requests
 inflect==0.2.5            # via jinja2-pluralize
-isort==4.2.5
+isort==4.2.15
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.9.6             # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.3.1  # via astroid
@@ -37,7 +38,7 @@ pip-tools==1.9.0
 pkginfo==1.4.1            # via twine
 pluggy==0.4.0             # via tox
 polib==1.0.8              # via edx-i18n-tools
-py==1.4.33                # via tox
+py==1.4.34                # via tox
 pycodestyle==2.3.1
 pydocstyle==1.1.1
 pygments==2.2.0           # via diff-cover, readme-renderer
@@ -46,15 +47,18 @@ pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.2.0          # via packaging
+pytz==2017.2              # via django
 pyyaml==3.12              # via edx-i18n-tools
 readme-renderer==17.2
-requests-toolbelt==0.7.1  # via twine
-requests==2.14.2          # via caniusepython3, requests-toolbelt, twine
+requests-toolbelt==0.8.0  # via twine
+requests==2.18.1          # via caniusepython3, requests-toolbelt, twine
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.10.0               # via astroid, bleach, diff-cover, edx-i18n-tools, edx-lint, html5lib, packaging, pip-tools, pylint, readme-renderer, singledispatch
+six==1.10.0
 tox-battery==0.4
 tox==2.7.0
-twine==1.8.1
+tqdm==4.14.0              # via twine
+twine==1.9.1
+urllib3==1.21.1           # via requests
 virtualenv==15.1.0        # via tox
 webencodings==0.5.1       # via html5lib
 wheel==0.29.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,6 +9,8 @@ astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-u
 backports.functools-lru-cache==1.4  # via astroid, caniusepython3, pylint
 bleach==2.0.0             # via readme-renderer
 caniusepython3==5.0.0
+certifi==2017.4.17        # via requests
+chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint
 configparser==3.5.0       # via pylint
@@ -18,7 +20,8 @@ edx-lint==0.5.4
 enum34==1.1.6             # via astroid
 futures==3.1.1            # via caniusepython3
 html5lib==0.999999999     # via bleach
-isort==4.2.5
+idna==2.5                 # via requests
+isort==4.2.15
 lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via pylint
 packaging==16.8           # via caniusepython3
@@ -31,8 +34,9 @@ pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.2.0          # via packaging
 readme-renderer==17.2
-requests==2.14.2          # via caniusepython3
+requests==2.18.1          # via caniusepython3
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.10.0               # via astroid, bleach, edx-lint, html5lib, packaging, pylint, readme-renderer, singledispatch
+urllib3==1.21.1           # via requests
 webencodings==0.5.1       # via html5lib
 wrapt==1.10.10            # via astroid

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,3 +4,4 @@
 pytest-catchlog           # Show log output for test failures
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
+six                       # Python 3 compatibility layer

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,9 +5,10 @@
 #    pip-compile --output-file requirements/test.txt requirements/base.in requirements/test.in
 #
 coverage==4.4.1           # via pytest-cov
-py==1.4.33                # via pytest, pytest-catchlog
+py==1.4.34                # via pytest, pytest-catchlog
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.0.7             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.1.2             # via pytest-catchlog, pytest-cov, pytest-django
 pytz==2017.2              # via django
+six==1.10.0

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,11 +4,15 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
+certifi==2017.4.17        # via requests
+chardet==3.0.4            # via requests
 codecov==2.0.9
 coverage==4.4.1           # via codecov
+idna==2.5                 # via requests
 pluggy==0.4.0             # via tox
-py==1.4.33                # via tox
-requests==2.14.2          # via codecov
+py==1.4.34                # via tox
+requests==2.18.1          # via codecov
 tox-battery==0.4
 tox==2.7.0
+urllib3==1.21.1           # via requests
 virtualenv==15.1.0        # via tox

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "Django>=1.8,<1.11"
+        "Django>=1.8,<2"
     ],
     license="AGPL 3.0",
     zip_safe=False,
@@ -58,6 +58,7 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35}-django{18,19,110}
+envlist = {py27,py35}-django{18,19,110,111}
 
 [pycodestyle]
 exclude = .git,.tox,migrations
@@ -23,6 +23,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2
     -r{toxinidir}/requirements/test.txt
 commands =
     py.test {posargs}


### PR DESCRIPTION
**Description:** Add testing for Django 1.11, add six to requirements, and bump dependency versions. Updated AUTHORS, version, and CHANGELOG.

**JIRA:** https://openedx.atlassian.net/browse/PLAT-1475

**Merge deadline:** 2017-07-17 is the soft deadline, but we'd like to get this version into edx-platform next sprint

**Testing instructions:**

1. Run tox

**Reviewers:**
- [x] @nedbat 
- [x] @macdiesel  

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)