### PR TITLE
Unpin tox-battery now that it is fixed

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,7 +10,3 @@
 
 # Stay on an LTS release
 django<2.3
-
-# tox-battery>0.5.2 throws exception when requirements.txt is not found.
-# Can be removed when https://github.com/signalpillar/tox-battery/pull/26 gets merged.
-tox-battery==0.5.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,7 +31,7 @@ mccabe==0.6.1             # via pylint
 packaging==20.4           # via bleach, tox
 path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
-pip-tools==5.1.2          # via -r requirements/dev.in
+pip-tools==5.2.0          # via -r requirements/dev.in
 pkginfo==1.5.0.1          # via twine
 pluggy==0.13.1            # via diff-cover, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -52,7 +52,7 @@ requests==2.23.0          # via requests-toolbelt, twine
 six==1.15.0               # via -r requirements/base.in, astroid, bleach, diff-cover, edx-i18n-tools, edx-lint, packaging, pip-tools, readme-renderer, tox, virtualenv
 sqlparse==0.3.1           # via django
 toml==0.10.1              # via tox
-tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev.in
+tox-battery==0.6.1        # via -r requirements/dev.in
 tox==3.15.1               # via -r requirements/dev.in, tox-battery
 tqdm==4.46.0              # via twine
 twine==1.15.0             # via -r requirements/dev.in

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -21,7 +21,7 @@ pyparsing==2.4.7          # via packaging
 requests==2.23.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/travis.in
+tox-battery==0.6.1        # via -r requirements/travis.in
 tox==3.15.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
 virtualenv==20.0.21       # via tox


### PR DESCRIPTION
https://github.com/signalpillar/tox-battery/pull/26 has been merged.
