### PR TITLE
Update PyPI token

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -27,4 +27,4 @@ jobs:
          uses: pypa/gh-action-pypi-publish@master
          with:
            user: __token__
-           password: ${{ PYPI_UPLOAD_TOKEN }}
+           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}

--- a/help_tokens/__init__.py
+++ b/help_tokens/__init__.py
@@ -4,6 +4,6 @@ Django app for linking to help pages with short tokens.
 
 from .context_processor import context_processor
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 
 default_app_config = 'help_tokens.apps.HelpTokensConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
**Issue:** [BOM-2209](https://openedx.atlassian.net/browse/BOM-2209)

### Description
- Updated PyPI credentials to use `secrets.PYPI_UPLOAD_TOKEN` as password.
- Bumped version to `1.1.3`.